### PR TITLE
user and group must should before a directory can be owned by them

### DIFF
--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -19,12 +19,6 @@
 # limitations under the License.
 #
 
-directory node['opendkim']['run_dir'] do
-  owner node['opendkim']['user']
-  group node['opendkim']['group']
-  mode '00755'
-end
-
 user node['opendkim']['user'] do
   comment 'OpenDKIM user'
   home node['opendkim']['run_dir']
@@ -36,4 +30,10 @@ group node['opendkim']['group'] do
   members [node['opendkim']['user']]
   system true
   append true
+end
+
+directory node['opendkim']['run_dir'] do
+  owner node['opendkim']['user']
+  group node['opendkim']['group']
+  mode '00755'
 end


### PR DESCRIPTION
I ran into this when writing a wrapper cookbook based on [this example](https://github.com/onddo/opendkim-cookbook#reading-the-key-from-a-chef-vault-bag).